### PR TITLE
Resolve SC2154 lint finding

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,8 +17,8 @@ runs:
   using: 'docker'
   image: 'Dockerfile'
   env:
-    action_format: ${{ inputs.format }}
-    action_filename: ${{ inputs.filename }}
+    ACTION_FORMAT: ${{ inputs.format }}
+    ACTION_FILENAME: ${{ inputs.filename }}
 
 branding:
   icon: 'book'  

--- a/entrypoint
+++ b/entrypoint
@@ -3,7 +3,7 @@ set -e
 
 command_string="latexmk"
 
-case "$action_format" in
+case "$ACTION_FORMAT" in
 	pdf)
 		command_string="$command_string -pdf"
 	;;
@@ -13,7 +13,7 @@ case "$action_format" in
 	;;
 esac
 
-if [ -n "$action_filename" ]
+if [ -n "$ACTION_FILENAME" ]
 then
 	command_string="$command_string $action_filename"
 fi

--- a/entrypoint
+++ b/entrypoint
@@ -15,7 +15,7 @@ esac
 
 if [ -n "$ACTION_FILENAME" ]
 then
-	command_string="$command_string $action_filename"
+	command_string="$command_string $ACTION_FILENAME"
 fi
 
 echo "Command: $command_string"


### PR DESCRIPTION
```
2020-09-01 21:52:52 [ERROR ]   [
In /github/workspace/entrypoint line 6:
case "$action_format" in
      ^------------^ SC2154: action_format is referenced but not assigned.


In /github/workspace/entrypoint line 16:
if [ -n "$action_filename" ]
         ^--------------^ SC2154: action_filename is referenced but not assigned.

For more information:
  https://www.shellcheck.net/wiki/SC2154 -- action_filename is referenced but...]
```