### PR TITLE
Accept dedicated configuration file

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -4,18 +4,21 @@ set -e
 command_string="latexmk"
 
 case "$ACTION_FORMAT" in
-	pdf)
-		command_string="$command_string -pdf"
-	;;
-	*)
-		echo "Invalid input for action argument: format (must be pdf)"
-		exit 1
-	;;
+    pdf)
+        command_string="$command_string -pdf"
+        ;;
+    *)
+        if [[ -f "latexmkrc" || -f ".latexmkrc" ]]; then
+            echo "Configuration file detected"
+        else
+            echo "Invalid input for action argument: format (must be pdf)"
+            exit 1
+        fi
+        ;;
 esac
 
-if [ -n "$ACTION_FILENAME" ]
-then
-	command_string="$command_string $ACTION_FILENAME"
+if [ -n "$ACTION_FILENAME" ]; then
+    command_string="$command_string $ACTION_FILENAME"
 fi
 
 echo "Command: $command_string"


### PR DESCRIPTION
Latexmk's option `-pdf` forces the use of `pdftex`. The proposed modification does not change the behavior of the action, except when a Latexmk configuration file is detected, in which case it uses it (for using, e.g., `xelatex`).