### PR TITLE
feat: Add arguments

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,12 +13,18 @@ inputs:
     required: false
     default: main.tex
 
+  arguments:
+    description: "Arguments passed to latexmk"
+    required: false
+    default: ""
+
 runs:
   using: 'docker'
   image: 'Dockerfile'
   env:
     ACTION_FORMAT: ${{ inputs.format }}
     ACTION_FILENAME: ${{ inputs.filename }}
+    ACTION_ARGS: ${{ inputs.arguments }}
 
 branding:
   icon: 'book'

--- a/entrypoint
+++ b/entrypoint
@@ -4,13 +4,13 @@ set -e
 command_string="latexmk"
 
 case "$ACTION_FORMAT" in
-    pdf)
-        command_string="$command_string -pdf"
-        ;;
-    *)
-        echo "Invalid input for action argument: format (must be pdf)"
-        exit 1
-        ;;
+	pdf)
+		command_string="$command_string -pdf"
+	;;
+	*)
+		echo "Invalid input for action argument: format (must be pdf)"
+		exit 1
+	;;
 esac
 if [ ! "$ACTION_ARGS" = "" ]; then
     for arg in $ACTION_ARGS; do
@@ -18,8 +18,9 @@ if [ ! "$ACTION_ARGS" = "" ]; then
     done
 fi
 
-if [ "$ACTION_FILENAME" != "" ]; then
-    command_string="$command_string $ACTION_FILENAME"
+if [ -n "$ACTION_FILENAME" ]
+then
+	command_string="$command_string $ACTION_FILENAME"
 fi
 
 echo "Command: $command_string"

--- a/entrypoint
+++ b/entrypoint
@@ -14,7 +14,14 @@ case "$ACTION_FORMAT" in
 esac
 if [ ! "$ACTION_ARGS" = "" ]; then
     for arg in $ACTION_ARGS; do
-        command_string="$command_string $arg"
+        case "$arg" in
+            -pvc)
+                continue
+                ;;
+            *)
+                command_string="$command_string $arg"
+                ;;
+        esac
     done
 fi
 

--- a/entrypoint
+++ b/entrypoint
@@ -13,7 +13,7 @@ case "$ACTION_FORMAT" in
         ;;
 esac
 if [ ! "$ACTION_ARGS" = "" ]; then
-    for arg in "${ACTION_ARGS[@]}"; do
+    for arg in $ACTION_ARGS; do
         command_string="$command_string $arg"
     done
 fi

--- a/entrypoint
+++ b/entrypoint
@@ -4,18 +4,22 @@ set -e
 command_string="latexmk"
 
 case "$ACTION_FORMAT" in
-	pdf)
-		command_string="$command_string -pdf"
-	;;
-	*)
-		echo "Invalid input for action argument: format (must be pdf)"
-		exit 1
-	;;
+    pdf)
+        command_string="$command_string -pdf"
+        ;;
+    *)
+        echo "Invalid input for action argument: format (must be pdf)"
+        exit 1
+        ;;
 esac
+if [ ! "$ACTION_ARGS" = "" ]; then
+    for arg in "${ACTION_ARGS[@]}"; do
+        command_string="$command_string $arg"
+    done
+fi
 
-if [ -n "$ACTION_FILENAME" ]
-then
-	command_string="$command_string $ACTION_FILENAME"
+if [ "$ACTION_FILENAME" != "" ]; then
+    command_string="$command_string $ACTION_FILENAME"
 fi
 
 echo "Command: $command_string"


### PR DESCRIPTION
This PR adds an option to pass any number of arguments to the `latexmk` command. Effectively this would also make the `format` option redundant.

I haven't done any testing, other than using it for one project as:

```yml
...
      - name: Generate PDF document
        # uses: hspaans/latexmk-action@v1
        uses: engeir/latexmk-action@add-arguments
        with:
          format: pdf
          filename: src/thesis.tex
          arguments: |
            -cd
            -output-directory="../build/"
...
```

A check for the `-pvc` argument is included, as the action would not finish otherwise. Not sure if more arguments should be restricted or if this is enough.