### PR TITLE
fix: :rotating_light: corrected SC2109 error

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 
 command_string="latexmk"
 
-if [ -f "latexmkrc" || -f ".latexmkrc" ]
+if [ -f "latexmkrc" ] || [ -f ".latexmkrc" ]
 then
 	echo "latexmkrc file found"
 else


### PR DESCRIPTION
Hi, I've created a pull request that corrected [SC2109 ](https://www.shellcheck.net/wiki/SC2109) error.

The following error occurred, so I fixed it:

```
./entrypoint.sh: line 7: [: missing `]'
./entrypoint.sh: line 7: -f: command not found
```

This error is related to SC2109, since `||` cannot be used inside `[ .. ]`.

 - ref: https://www.shellcheck.net/wiki/SC2109

Could someone please review it and provide feedback?

