### PR TITLE
Potential fix for code scanning alert no. 4741: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -26,6 +26,8 @@ jobs:
   build-test:
     name: Container Test Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout the code
@@ -45,6 +47,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-test
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Checkout Code


### PR DESCRIPTION
Potential fix for [https://github.com/hspaans/latexmk-action/security/code-scanning/4741](https://github.com/hspaans/latexmk-action/security/code-scanning/4741)

Add explicit `permissions` blocks so each job gets only what it needs:

- `build-test` only checks out code and runs local Docker commands → `contents: read`.
- `build-release` checks out code and pushes to GHCR using `GITHUB_TOKEN` → `contents: read` and `packages: write`.

Best minimal-change fix: add job-level permissions under each job in `.github/workflows/docker-image.yml`, preserving existing behavior while enforcing least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
